### PR TITLE
cleanup kubeconfig and vm storage

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -240,6 +240,7 @@ function clean_resources() {
     rm -rf "$GENERATED_DIR" || true
     rm -f "kubeconfig.$CLUSTER_NAME" || true
     rm -f "$HOSTED_CLUSTER_NAME.kubeconfig" || true
+    rm -f "$KUBECONFIG" || true
     
     log "INFO" "Cleanup complete"
 }

--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -86,7 +86,7 @@ function delete_vms() {
         if ! virsh destroy ${vm} 2>/dev/null; then
             log "WARNING" "Failed to destroy VM ${vm}, continuing anyway"
         fi
-        if ! virsh undefine ${vm} 2>/dev/null; then
+        if ! virsh undefine ${vm} --remove-all-storage 2>/dev/null; then
             log "WARNING" "Failed to undefine VM ${vm}, continuing anyway"
         fi
     done


### PR DESCRIPTION
Issues this pull request addresses:

1. `make clean-all` leaves one of the (duplicated) kubeconfig's behind, leading to issues when re-deploying.
```
$ ls -l kubeconfig.*
-rw-rw-r-- 1 mwiget mwiget 8978 May  9 04:18 kubeconfig.doca-cluster
-rw-rw-r-- 1 mwiget mwiget 8978 May  9 04:18 kubeconfig.mw-doca-cluster
```

The change simply cleans up the leftover kubeconfig. Likely a better solution would be to only have one kubeconfig using the cluster name.

2. `make clean-all` destroys the control node VMs but leaves the virtual disk image behind. Proposed change removes them.

