### PR TITLE
feat: update-etc-hosts now adds both API and console endpoints to /et…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,8 @@ redeploy-dpu:
 	@$(POST_INSTALL_SCRIPT) redeploy
 
 update-etc-hosts:
-	@scripts/update-etc-hosts.sh
+	@scripts/update-etc-hosts.sh $(API_VIP) api.$(CLUSTER_NAME).$(BASE_DOMAIN)
+	@scripts/update-etc-hosts.sh $(INGRESS_VIP) console-openshift-console.apps.$(CLUSTER_NAME).$(BASE_DOMAIN)
 
 clean-all:
 	@$(CLUSTER_SCRIPT) clean-all


### PR DESCRIPTION
**Summary**

This PR improves the developer and user experience by updating the update-etc-hosts Makefile target to add both the OpenShift API and web console endpoints to /etc/hosts. This makes it easier to access the cluster in environments without DNS.

**Details**

- The update-etc-hosts target now calls the script twice:
    - Once for the API endpoint:
        - api.<CLUSTER_NAME>.<BASE_DOMAIN> → API_VIP

    - Once for the console endpoint:
        - console-openshift-console.apps.<CLUSTER_NAME>.<BASE_DOMAIN> → INGRESS_VIP

- This ensures that both the OpenShift API and web console are resolvable from the local machine.
- Wildcards are not supported in /etc/hosts, so each app route must be added individually if needed.

**Why**

- Many users run OpenShift clusters in lab, POC, or air-gapped environments where DNS is not available.
- This change provides a simple, automated way to make the cluster accessible via /etc/hosts, reducing manual steps and potential errors.

**Usage**
After setting the correct values in your .env file, simply run:
make update-etc-hosts

This will update /etc/hosts with both the API and console endpoints.
> Note:
> If you need to access additional app routes, you must add a line for each app route and point it to the Ingress VIP.
