### PR TITLE
sudo privileges are enough, no need to run as root

### DIFF
--- a/scripts/update-etc-hosts.sh
+++ b/scripts/update-etc-hosts.sh
@@ -14,11 +14,13 @@ print_usage() {
     echo "Example with VM prefix: $0 192.168.1.100 myserver.example.com myvm"
 }
 
-# Check if script is run with sudo/root privileges
-check_root() {
-    if [ "$EUID" -ne 0 ]; then
-        echo "Please run with sudo privileges"
-        exit 1
+check_sudo_access() {
+    local user="$1"
+
+    if sudo -l -U "$user" >/dev/null 2>&1; then
+        echo "User '$user' has sudo privileges."
+    else
+        echo "User '$user' does NOT have sudo privileges."
     fi
 }
 
@@ -165,5 +167,5 @@ main() {
 }
 
 # Script execution starts here
-check_root
+#check_sudo_access
 main "$@"


### PR DESCRIPTION
scripts/update-etc-hosts.sh checks if the script runs as user root despite using sudo in places where elevated privileges are required.

The proposed change replaces check_root() with heck_sudo_access(), though probably the check could be removed completely. The user would simply be asked for a password, with the new check just once more if sudo requires a password.
