### PR TITLE
feat: Add service templates for OVN and HBN

### DIFF
--- a/manifests/post-installation/hbn-configuration.yaml
+++ b/manifests/post-installation/hbn-configuration.yaml
@@ -1,0 +1,95 @@
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceConfiguration
+metadata:
+  name: hbn
+  namespace: dpf-operator-system
+spec:
+  deploymentServiceName: "hbn"
+  serviceConfiguration:
+    serviceDaemonSet:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |-
+          [
+          {"name": "iprequest", "interface": "ip_lo", "cni-args": {"poolNames": ["loopback"], "poolType": "cidrpool"}},
+          {"name": "iprequest", "interface": "ip_pf2dpu2", "cni-args": {"poolNames": ["pool1"], "poolType": "cidrpool", "allocateDefaultGateway": true}}
+          ]
+    helmChart:
+      values:
+        configuration:
+          perDPUValuesYAML: |
+            - hostnamePattern: "*"
+              values:
+                bgp_peer_group: hbn
+            - hostnamePattern: "srv24-*"
+              values:
+                bgp_autonomous_system: 65101
+            - hostnamePattern: "srv25-*"
+              values:
+                bgp_autonomous_system: 65201
+          startupYAMLJ2: |
+            - header:
+                model: BLUEFIELD
+                nvue-api-version: nvue_v1
+                rev-id: 1.0
+                version: HBN 2.4.0
+            - set:
+                interface:
+                  lo:
+                    ip:
+                      address:
+                        {{ ipaddresses.ip_lo.ip }}/32: {}
+                    type: loopback
+                  p0_if,p1_if:
+                    type: swp
+                    link:
+                      mtu: 9000
+                  pf2dpu2_if:
+                    ip:
+                      address:
+                        {{ ipaddresses.ip_pf2dpu2.cidr }}: {}
+                    type: swp
+                    link:
+                      mtu: 9000
+                router:
+                  bgp:
+                    autonomous-system: {{ config.bgp_autonomous_system }}
+                    enable: on
+                    graceful-restart:
+                      mode: full
+                    router-id: {{ ipaddresses.ip_lo.ip }}
+                vrf:
+                  default:
+                    router:
+                      bgp:
+                        address-family:
+                          ipv4-unicast:
+                            enable: on
+                            redistribute:
+                              connected:
+                                enable: on
+                          ipv6-unicast:
+                            enable: on
+                            redistribute:
+                              connected:
+                                enable: on
+                        enable: on
+                        neighbor:
+                          p0_if:
+                            peer-group: {{ config.bgp_peer_group }}
+                            type: unnumbered
+                          p1_if:
+                            peer-group: {{ config.bgp_peer_group }}
+                            type: unnumbered
+                        path-selection:
+                          multipath:
+                            aspath-ignore: on
+                        peer-group:
+                          {{ config.bgp_peer_group }}:
+                            remote-as: external
+  interfaces:
+    - name: p0_if
+      network: mybrhbn
+    - name: p1_if
+      network: mybrhbn
+    - name: pf2dpu2_if
+      network: mybrhbn

--- a/manifests/post-installation/hbn-template.yaml
+++ b/manifests/post-installation/hbn-template.yaml
@@ -1,0 +1,19 @@
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceTemplate
+metadata:
+  name: hbn
+  namespace: dpf-operator-system
+spec:
+  deploymentServiceName: "hbn"
+  helmChart:
+    source:
+      repoURL: https://helm.ngc.nvidia.com/nvidia/doca
+      version: "1.0.2"
+      chart: doca-hbn
+    values:
+      image:
+        repository: quay.io/itsoiref/hbn
+        tag: 25.4-doca-3.0-1
+      resources:
+        memory: 6Gi
+        nvidia.com/bf_sf: 3

--- a/manifests/post-installation/ovn-configuration.yaml
+++ b/manifests/post-installation/ovn-configuration.yaml
@@ -1,0 +1,24 @@
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceConfiguration
+metadata:
+  name: ovn
+  namespace: dpf-operator-system
+spec:
+  deploymentServiceName: "ovn"
+  serviceConfiguration:
+    helmChart:
+      values:
+        global:
+          imagePullSecretName: "dpf-pull-secret"
+        k8sAPIServer: https://HOST_CLUSTER_API:6443
+        podNetwork: 10.128.0.0/16
+        serviceNetwork: 172.30.0.0/16
+        mtu: 1400
+        dpuManifests:
+          kubernetesSecretName: "ovn-dpu"
+          vtepCIDR: "HBN_OVN_NETWORK"
+          hostCIDR: "DPU_HOST_CIDR"
+          ipamPool: "pool1"
+          ipamPoolType: "cidrpool"
+          ipamVTEPIPIndex: 0
+          ipamPFIPIndex: 1

--- a/manifests/post-installation/ovn-template.yaml
+++ b/manifests/post-installation/ovn-template.yaml
@@ -1,0 +1,31 @@
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceTemplate
+metadata:
+  name: ovn
+  namespace: dpf-operator-system
+spec:
+  deploymentServiceName: "ovn"
+  helmChart:
+    source:
+      repoURL: oci://quay.io/szigmon
+      chart: ovn
+      version: "v25.4.0-custom"
+    values:
+      nameOverride: "ovn-kubernetes"
+      commonManifests:
+        enabled: true
+      dpuManifests:
+        enabled: true
+        cniBinDir: /var/lib/cni/bin/
+        cniConfDir: /run/multus/cni/net.d
+        dpuServiceAccountNamespace: "dpf-operator-system"
+      controlPlaneManifests:
+        enabled: false
+      nodeWithDPUManifests:
+        enabled: false
+      nodeWithoutDPUManifests:
+        enabled: false
+      ovn-kubernetes-resource-injector:
+        enabled: false
+      leaseNamespace: "ovn-kubernetes"
+      gatewayOpts: "--gateway-interface=br-ovn --gateway-uplink-port=puplinkbrovn"


### PR DESCRIPTION
## Summary
Add service templates and configurations for OVN and HBN services to work with DPUDeployment.

## Changes
- ovn-template.yaml - OVN service template with helm chart configuration
- ovn-configuration.yaml - OVN service configuration with network settings
- hbn-template.yaml - HBN service template v1.0.2 
- hbn-configuration.yaml - HBN service configuration with BGP settings

## Notes
These templates are required for the DPUDeployment resource to deploy services.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>