### PR TITLE
chore: Update gitignore for local documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,10 @@ node-feature-discovery
 
 # discovery iso
 discovery_image*
+
+# Documentation
+CLAUDE.md
+
+# Claude directory
+.claude/
 	


### PR DESCRIPTION
## Summary
- Update .gitignore to exclude local documentation files and directories

## Changes
- Added entries to .gitignore for local documentation that should not be tracked in the repository

## Purpose
Keep project-specific local documentation separate from the main repository.