### PR TITLE
feat: Add DTS and Blueman service templates

### DIFF
--- a/manifests/post-installation/blueman-configuration.yaml
+++ b/manifests/post-installation/blueman-configuration.yaml
@@ -1,0 +1,12 @@
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceConfiguration
+metadata:
+  name: doca-blueman-service
+  namespace: dpf-operator-system
+spec:
+  deploymentServiceName: "doca-blueman-service"
+  serviceConfiguration:
+    helmChart:
+      values:
+        imagePullSecrets:
+        - name: dpf-pull-secret

--- a/manifests/post-installation/blueman-template.yaml
+++ b/manifests/post-installation/blueman-template.yaml
@@ -1,0 +1,16 @@
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceTemplate
+metadata:
+  name: doca-blueman-service
+  namespace: dpf-operator-system
+spec:
+  deploymentServiceName: "doca-blueman-service"
+  resourceRequirements:
+    cpu: 1
+    memory: 1Gi
+    storage: 1Gi
+  helmChart:
+    source:
+      repoURL: https://helm.ngc.nvidia.com/nvidia/doca
+      chart: doca-blueman
+      version: "1.0.5"

--- a/manifests/post-installation/dts-configuration.yaml
+++ b/manifests/post-installation/dts-configuration.yaml
@@ -1,0 +1,8 @@
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceConfiguration
+metadata:
+  name: doca-telemetry-service
+  namespace: dpf-operator-system
+spec:
+  deploymentServiceName: "doca-telemetry-service"
+  serviceConfiguration: {}

--- a/manifests/post-installation/dts-template.yaml
+++ b/manifests/post-installation/dts-template.yaml
@@ -1,0 +1,16 @@
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceTemplate
+metadata:
+  name: doca-telemetry-service
+  namespace: dpf-operator-system
+spec:
+  deploymentServiceName: "doca-telemetry-service"
+  resourceRequirements:
+    cpu: 1
+    memory: 1Gi
+    storage: 1Gi
+  helmChart:
+    source:
+      repoURL: https://helm.ngc.nvidia.com/nvidia/doca
+      chart: doca-telemetry
+      version: "0.2.3"


### PR DESCRIPTION
## Summary
- Add DTS (DOCA Telemetry Service) templates for DPU deployment
- Add Blueman service templates for DPU management
- Complete service template collection for DPF v25.4.0

## Changes included
From PR #32 (DTS and Blueman parts only):
- Add dts-template.yaml and dts-configuration.yaml
- Add blueman-template.yaml and blueman-configuration.yaml

## Testing
- Tested DTS deployment with new templates
- Verified Blueman service configuration works correctly
- Confirmed both services integrate properly with DPF

This extracts the DTS and Blueman templates from PR #32, separate from Flannel.