### PR TITLE
feat: Apply script updates from PR #46 for v25.4.0 compatibility

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -46,7 +46,6 @@ CLUSTER_NAME=${CLUSTER_NAME:-"doca"}
 BASE_DOMAIN=${BASE_DOMAIN:-"lab.nvidia.com"}
 OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-"4.14.0"}
 KUBECONFIG=${KUBECONFIG:-"./${CLUSTER_NAME}-kubeconfig"}
-DPF_CLUSTER_TYPE=${DPF_CLUSTER_TYPE:-"hypershift"}
 SSH_KEY=${SSH_KEY:-"$HOME/.ssh/id_rsa.pub"}
 
 # Network Configuration
@@ -73,14 +72,17 @@ BRIDGE_NAME=${BRIDGE_NAME:-br0}
 SKIP_BRIDGE_CONFIG=${SKIP_BRIDGE_CONFIG:-"false"}
 
 # DPF Configuration
+DPF_VERSION="v25.4.0"
+DPF_HELM_REPO_URL=${DPF_HELM_REPO_URL:-"https://helm.ngc.nvidia.com/nvidia/doca/charts/dpf-operator"}
 HOST_CLUSTER_API=${HOST_CLUSTER_API:-"api.$CLUSTER_NAME.$BASE_DOMAIN"}
-KAMAJI_VIP=${KAMAJI_VIP:-"10.1.178.225"}
+
 if [ "${VM_COUNT}" -lt 2 ]; then
   ETCD_STORAGE_CLASS=${ETCD_STORAGE_CLASS:-"lvms-vg1"}
+  BFB_STORAGE_CLASS=${BFB_STORAGE_CLASS:-"nfs-client"}
 else
   ETCD_STORAGE_CLASS=${ETCD_STORAGE_CLASS:-"ocs-storagecluster-ceph-rbd"}
+  BFB_STORAGE_CLASS=${BFB_STORAGE_CLASS:-""}
 fi
-BFB_STORAGE_CLASS=${BFB_STORAGE_CLASS:-""}
 NUM_VFS=${NUM_VFS:-"46"}
 
 # Feature Configuration

--- a/scripts/manifests.sh
+++ b/scripts/manifests.sh
@@ -170,7 +170,7 @@ function generate_ovn_manifests() {
 
     # Pull and template OVN chart
     helm pull oci://ghcr.io/nvidia/ovn-kubernetes-chart \
-        --version "$HELM_CHART_VERSION" \
+        --version "$DPF_VERSION" \
         --untar -d "$GENERATED_DIR/temp"
     helm template -n ovn-kubernetes ovn-kubernetes \
         "$GENERATED_DIR/temp/ovn-kubernetes-chart" \

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -28,9 +28,14 @@ mkdir -p "${GENERATED_POST_INSTALL_DIR}"
 SPECIAL_FILES=(
     "bfb.yaml"
     "hbn-ovn-ipam.yaml"
-    "ovn-dpuservice.yaml"
     "dpuflavor-1500.yaml"
     "sriov-policy.yaml"
+    "ovn-template.yaml"
+    "ovn-configuration.yaml"
+    "hbn-template.yaml"
+    "dts-template.yaml"
+    "blueman-template.yaml"
+    "flannel-template.yaml"
 )
 
 # Function to check if a file is in the special files list
@@ -81,8 +86,11 @@ function update_bfb_manifest() {
 function update_hbn_ovn_manifests() {
     log [INFO] "Updating HBN OVN manifests..."
     
-    machineCidr=$(oc get configmap cluster-config-v1 -n kube-system -o jsonpath='{.data.install-config}' | \
-    grep -A2 "machineNetwork:" | grep "cidr:" | awk '{print $3}')
+    # DPU_HOST_CIDR must be set by user
+    if [ -z "${DPU_HOST_CIDR}" ]; then
+        log [ERROR] "DPU_HOST_CIDR environment variable is not set. Please set it to the DPU nodes subnet (e.g., 10.6.135.0/24)"
+        return 1
+    fi
     # Update hbn-ovn-ipam.yaml
     update_file_multi_replace \
         "${POST_INSTALL_DIR}/hbn-ovn-ipam.yaml" \
@@ -90,13 +98,26 @@ function update_hbn_ovn_manifests() {
         "HBN_OVN_NETWORK" \
         "${HBN_OVN_NETWORK}"
     
-    # Update ovn-dpuservice.yaml with multiple replacements
-    update_file_multi_replace \
-        "${POST_INSTALL_DIR}/ovn-dpuservice.yaml" \
-        "${GENERATED_POST_INSTALL_DIR}/ovn-dpuservice.yaml" \
-        "HBN_OVN_NETWORK" "${HBN_OVN_NETWORK}" \
-        "HOST_CLUSTER_API" "${HOST_CLUSTER_API}" \
-        "HOST_CIDR" "${machineCidr}"
+    # Skip ovn-dpuservice.yaml - now handled by DPUDeployment
+    # Services are now managed through DPUDeployment with templates and configurations
+    
+    # Update ovn-template.yaml for DPUDeployment
+    if [ -f "${POST_INSTALL_DIR}/ovn-template.yaml" ]; then
+        update_file_multi_replace \
+            "${POST_INSTALL_DIR}/ovn-template.yaml" \
+            "${GENERATED_POST_INSTALL_DIR}/ovn-template.yaml" \
+            "DPF_VERSION" "${DPF_VERSION}"
+    fi
+    
+    # Update ovn-configuration.yaml for DPUDeployment
+    if [ -f "${POST_INSTALL_DIR}/ovn-configuration.yaml" ]; then
+        update_file_multi_replace \
+            "${POST_INSTALL_DIR}/ovn-configuration.yaml" \
+            "${GENERATED_POST_INSTALL_DIR}/ovn-configuration.yaml" \
+            "HBN_OVN_NETWORK" "${HBN_OVN_NETWORK}" \
+            "HOST_CLUSTER_API" "${HOST_CLUSTER_API}" \
+            "DPU_HOST_CIDR" "${DPU_HOST_CIDR}"
+    fi
     
     log [INFO] "HBN OVN manifests updated successfully"
 }
@@ -127,6 +148,26 @@ function update_vf_configuration() {
     log [INFO] "VF configuration updated successfully"
 }
 
+# Function to update service template versions
+function update_service_templates() {
+    log [INFO] "Updating service template versions..."
+    
+    # Update all service templates with DPF_VERSION if they exist
+    local templates=("hbn-template.yaml" "dts-template.yaml" "blueman-template.yaml" "flannel-template.yaml")
+    
+    for template in "${templates[@]}"; do
+        if [ -f "${POST_INSTALL_DIR}/${template}" ]; then
+            update_file_multi_replace \
+                "${POST_INSTALL_DIR}/${template}" \
+                "${GENERATED_POST_INSTALL_DIR}/${template}" \
+                "DPF_VERSION" "${DPF_VERSION}"
+            log [INFO] "Updated ${template} with DPF_VERSION=${DPF_VERSION}"
+        fi
+    done
+    
+    log [INFO] "Service template versions updated successfully"
+}
+
 # Function to prepare post-installation manifests
 function prepare_post_installation() {
     log [INFO] "Starting post-installation manifest preparation..."
@@ -141,6 +182,7 @@ function prepare_post_installation() {
     update_bfb_manifest
     update_hbn_ovn_manifests
     update_vf_configuration
+    update_service_templates
     
     # Copy remaining manifests
     for file in "${POST_INSTALL_DIR}"/*.yaml; do
@@ -171,25 +213,48 @@ function apply_post_installation() {
     # Get kubeconfig
     get_kubeconfig
     
-    # Apply each YAML file in the generated post-installation directory, except dpuset.yaml
+    # Wait for DPF provisioning webhook to be ready before applying manifests
+    log [INFO] "Waiting for DPF provisioning webhook service to be ready..."
+    local webhook_ready=false
+    local max_attempts=30
+    local attempt=0
+    
+    while [ $attempt -lt $max_attempts ] && [ "$webhook_ready" = "false" ]; do
+        attempt=$((attempt + 1))
+        
+        # Check if webhook endpoints are available
+        if oc get endpoints -n dpf-operator-system dpf-provisioning-webhook-service -o jsonpath='{.subsets[*].addresses[*].ip}' 2>/dev/null | grep -q .; then
+            log [INFO] "DPF provisioning webhook service is ready"
+            webhook_ready=true
+        else
+            if [ $attempt -eq 1 ]; then
+                log [INFO] "Waiting for webhook endpoints to be available..."
+            fi
+            sleep 2
+        fi
+    done
+    
+    if [ "$webhook_ready" = "false" ]; then
+        log [WARN] "DPF provisioning webhook service not ready after $max_attempts attempts, proceeding anyway..."
+    fi
+    
+    # Apply each YAML file in the generated post-installation directory
     for file in "${GENERATED_POST_INSTALL_DIR}"/*.yaml; do
         if [ -f "$file" ]; then
             local filename=$(basename "$file")
-            # Skip dpudeployment.yaml as it will be applied last
-            if [[ "${filename}" != "dpudeployment.yaml" ]]; then
+            # Special handling for SCC - must be applied to hosted cluster
+            if [[ "${filename}" == "dpu-services-scc.yaml" ]] && [[ -f "${HOSTED_CLUSTER_NAME}.kubeconfig" ]]; then
+                log [INFO] "Applying SCC to hosted cluster: ${filename}"
+                local saved_kubeconfig="${KUBECONFIG}"
+                export KUBECONFIG="${HOSTED_CLUSTER_NAME}.kubeconfig"
+                apply_manifest "$file" "true"
+                export KUBECONFIG="${saved_kubeconfig}"
+            else
                 log [INFO] "Applying post-installation manifest: ${filename}"
                 apply_manifest "$file" "true"
             fi
         fi
     done
-    
-    # Apply dpudeployment.yaml last if it exists, with apply_always=true
-    if [ -f "${GENERATED_POST_INSTALL_DIR}/dpudeployment.yaml" ]; then
-        log [INFO] "Applying dpudeployment.yaml (last manifest)..."
-        apply_manifest "${GENERATED_POST_INSTALL_DIR}/dpudeployment.yaml" "true"
-    else
-        log [WARN] "dpudeployment.yaml not found in ${GENERATED_POST_INSTALL_DIR}"
-    fi
     
     log [INFO] "Post-installation manifest application completed successfully"
 }
@@ -199,7 +264,6 @@ function redeploy() {
     prepare_post_installation
 
     log [INFO] "Deleting existing manifests..."
-    oc delete -f "${GENERATED_POST_INSTALL_DIR}/dpudeployment.yaml" || true
     oc delete -f "${GENERATED_POST_INSTALL_DIR}/bfb.yaml" || true
 
     # wait till all dpu are removed


### PR DESCRIPTION
## Summary
This PR extracts the unique script changes from PR #46 that haven't been merged to main yet.

## Changes
### post-install.sh
- Add webhook readiness check before applying manifests (waits up to 60s)
- Update template handling for DPUDeployment architecture
- Require DPU_HOST_CIDR environment variable from user
- Add SCC special handling for hosted clusters
- Remove dpudeployment.yaml from redeploy function
- Add update_service_templates() function for DPF service templates

### env.sh
- Add DPF_VERSION="v25.4.0"
- Add DPF_HELM_REPO_URL for NGC helm repo
- Remove DPF_CLUSTER_TYPE and KAMAJI_VIP (Kamaji no longer supported)
- Set BFB_STORAGE_CLASS=nfs-client for single VM deployments

### manifests.sh
- Change from HELM_CHART_VERSION to DPF_VERSION variable

## Testing
These changes were tested as part of the v25.4.0 branch deployment.

## Context
This addresses the script changes from PR #46 that were identified as not yet merged to main. This resolves the conflicts identified in PR #46's post-install.sh.

Related to PR #53 which contains the manifest changes from PR #45.