### PR TITLE
Updated DTS chart to 1.0.8 to run on DPF 25.04 with RHCOS BFB

### DIFF
--- a/manifests/post-installation/dts-template.yaml
+++ b/manifests/post-installation/dts-template.yaml
@@ -13,4 +13,6 @@ spec:
     source:
       repoURL: https://helm.ngc.nvidia.com/nvidia/doca
       chart: doca-telemetry
-      version: "0.2.3"
+      version: "1.0.8"
+    values:
+      hostVolumePrefix: "/var/lib"


### PR DESCRIPTION
Updated DTS chart to 1.0.8 and added hostVolumePrefix for DTS to use /var/lib instead of /opt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Helm chart version for the telemetry component.
  * Added a configuration option to set the host volume prefix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->