### PR TITLE
fixed missing source for tools.sh in enable-ovn-injector.sh

### DIFF
--- a/scripts/enable-ovn-injector.sh
+++ b/scripts/enable-ovn-injector.sh
@@ -8,6 +8,7 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/utils.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/env.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/cluster.sh"
+source "$(dirname "${BASH_SOURCE[0]}")/tools.sh"
 
 # Set cluster-specific values
 API_SERVER="api.$CLUSTER_NAME.$BASE_DOMAIN:6443"


### PR DESCRIPTION
Added source command for tools.sh to overcome this error:
`# make enable-ovn-injector
scripts/enable-ovn-injector.sh: line 19: ensure_helm_installed: command not found
make: *** [Makefile:107: enable-ovn-injector] Error 127`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved script environment setup for enhanced reliability.
  * Added minor formatting update for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->