### PR TITLE
Add MAC address assignment options for VM creation

### DIFF
--- a/MAC_ADDRESS_CONFIGURATION.md
+++ b/MAC_ADDRESS_CONFIGURATION.md
@@ -4,19 +4,12 @@ This document explains the MAC address assignment options available when creatin
 
 ## Configuration Options
 
-The script supports three MAC address assignment methods controlled by the `MAC_ASSIGNMENT_METHOD` environment variable:
+The script supports two MAC address assignment methods controlled by the `MAC_PREFIX` environment variable:
 
-### 1. No Static MAC Assignment (Default)
+### 1. Machine-ID Based MAC Generation (Default)
 ```bash
-export MAC_ASSIGNMENT_METHOD="none"
-# or leave unset (default behavior)
-```
-
-**Behavior**: VMs are created with randomly generated MAC addresses by libvirt.
-
-### 2. Machine-ID Based MAC Generation
-```bash
-export MAC_ASSIGNMENT_METHOD="machine-id"
+# Leave MAC_PREFIX unset or set to empty
+export MAC_PREFIX=""
 ```
 
 **Behavior**: 
@@ -26,75 +19,58 @@ export MAC_ASSIGNMENT_METHOD="machine-id"
 - Format: `52:54:00:XX:XX:XX` where XX are derived from machine-id hash
 
 **Requirements**: 
-- Host must have `/etc/machine-id` or `/var/lib/dbus/machine-id` file
+- Host must have `/etc/machine-id` file
 
-### 3. Custom Prefix MAC Generation
+### 2. Custom Prefix MAC Generation
 ```bash
-export MAC_ASSIGNMENT_METHOD="custom-prefix"
-export MAC_CUSTOM_PREFIX="C0:00"  # 2-digit hex value or 4-digit with colon
+export MAC_PREFIX="C0:00"  # 2-digit hex value or 4-digit with colon
 ```
 
 **Behavior**:
 - Generates MAC addresses with a custom prefix
-- Supports two formats:
-  - 2-digit format: `52:54:00:XX:00:YY` where XX is your custom prefix and YY is the VM index
-  - 4-digit format: `52:54:00:XX:YY:ZZ` where XX:YY is your custom prefix and ZZ is the VM index
+- Format: `52:54:00:XX:YY:ZZ` where XX:YY is your custom prefix and ZZ is the VM index
 - Examples:
-  - With `MAC_CUSTOM_PREFIX="01"`:
-    - vm-dpf1: `52:54:00:01:00:01`
-    - vm-dpf2: `52:54:00:01:00:02`
-  - With `MAC_CUSTOM_PREFIX="C0:00"`:
+  - With `MAC_PREFIX="C0:00"`:
     - vm-dpf1: `52:54:00:C0:00:01`
     - vm-dpf2: `52:54:00:C0:00:02`
+  - With `MAC_PREFIX="A1:B2"`:
+    - vm-dpf1: `52:54:00:A1:B2:01`
+    - vm-dpf2: `52:54:00:A1:B2:02`
 
 **Requirements**:
-- `MAC_CUSTOM_PREFIX` must be set to either:
-  - 2-digit hexadecimal value (e.g., "01", "A1", "FF")
-  - 4-digit hexadecimal value with colon (e.g., "C0:00", "A1:B2")
+- `MAC_PREFIX` must be set to a 4-digit hexadecimal value with colon (e.g., "C0:00", "A1:B2", "FF:EE")
 
 ## Usage Examples
 
-### Example 1: Use default random MAC addresses
+### Example 1: Use machine-id based MAC addresses (default)
 ```bash
 # No environment variables needed (default behavior)
 ./scripts/vm.sh create
 ```
 
-### Example 2: Use machine-id based MAC addresses
+### Example 2: Use custom prefix MAC addresses
 ```bash
-export MAC_ASSIGNMENT_METHOD="machine-id"
+export MAC_PREFIX="C0:00"
 ./scripts/vm.sh create
 ```
 
-### Example 3: Use custom prefix MAC addresses
-```bash
-export MAC_ASSIGNMENT_METHOD="custom-prefix"
-export MAC_CUSTOM_PREFIX="C0:00"
-./scripts/vm.sh create
-```
-
-### Example 4: Using .env file
+### Example 3: Using .env file
 Add to your `.env` file:
 ```bash
-MAC_ASSIGNMENT_METHOD=custom-prefix
-MAC_CUSTOM_PREFIX=C0:00
+MAC_PREFIX=C0:00
 ```
 
 ## Validation
 
 The script includes validation for:
-- MAC address format (proper hex format with colons)
-- Custom prefix format (2-digit hex or 4-digit hex with colon)
+- Custom prefix format (4-digit hex with colon)
 - Machine-id file existence
-- Valid assignment method values
 
 ## Error Handling
 
 The script will exit with an error if:
-- Invalid `MAC_ASSIGNMENT_METHOD` is specified
-- `MAC_CUSTOM_PREFIX` is missing when using "custom-prefix" method
-- Machine-id file is not found when using "machine-id" method
-- Generated MAC address is invalid
+- Invalid `MAC_PREFIX` format is specified
+- `/etc/machine-id` file is not found when using default method
 
 ## Notes
 

--- a/MAC_ADDRESS_CONFIGURATION.md
+++ b/MAC_ADDRESS_CONFIGURATION.md
@@ -1,0 +1,104 @@
+# MAC Address Configuration for VM Creation
+
+This document explains the MAC address assignment options available when creating VMs with the `vm.sh` script.
+
+## Configuration Options
+
+The script supports three MAC address assignment methods controlled by the `MAC_ASSIGNMENT_METHOD` environment variable:
+
+### 1. No Static MAC Assignment (Default)
+```bash
+export MAC_ASSIGNMENT_METHOD="none"
+# or leave unset (default behavior)
+```
+
+**Behavior**: VMs are created with randomly generated MAC addresses by libvirt.
+
+### 2. Machine-ID Based MAC Generation
+```bash
+export MAC_ASSIGNMENT_METHOD="machine-id"
+```
+
+**Behavior**: 
+- Generates deterministic MAC addresses based on the host's machine-id and VM name
+- Uses QEMU's standard locally administered MAC prefix: `52:54:00`
+- Ensures consistent MAC addresses across VM recreations on the same host
+- Format: `52:54:00:XX:XX:XX` where XX are derived from machine-id hash
+
+**Requirements**: 
+- Host must have `/etc/machine-id` or `/var/lib/dbus/machine-id` file
+
+### 3. Custom Prefix MAC Generation
+```bash
+export MAC_ASSIGNMENT_METHOD="custom-prefix"
+export MAC_CUSTOM_PREFIX="C0:00"  # 2-digit hex value or 4-digit with colon
+```
+
+**Behavior**:
+- Generates MAC addresses with a custom prefix
+- Supports two formats:
+  - 2-digit format: `52:54:00:XX:00:YY` where XX is your custom prefix and YY is the VM index
+  - 4-digit format: `52:54:00:XX:YY:ZZ` where XX:YY is your custom prefix and ZZ is the VM index
+- Examples:
+  - With `MAC_CUSTOM_PREFIX="01"`:
+    - vm-dpf1: `52:54:00:01:00:01`
+    - vm-dpf2: `52:54:00:01:00:02`
+  - With `MAC_CUSTOM_PREFIX="C0:00"`:
+    - vm-dpf1: `52:54:00:C0:00:01`
+    - vm-dpf2: `52:54:00:C0:00:02`
+
+**Requirements**:
+- `MAC_CUSTOM_PREFIX` must be set to either:
+  - 2-digit hexadecimal value (e.g., "01", "A1", "FF")
+  - 4-digit hexadecimal value with colon (e.g., "C0:00", "A1:B2")
+
+## Usage Examples
+
+### Example 1: Use default random MAC addresses
+```bash
+# No environment variables needed (default behavior)
+./scripts/vm.sh create
+```
+
+### Example 2: Use machine-id based MAC addresses
+```bash
+export MAC_ASSIGNMENT_METHOD="machine-id"
+./scripts/vm.sh create
+```
+
+### Example 3: Use custom prefix MAC addresses
+```bash
+export MAC_ASSIGNMENT_METHOD="custom-prefix"
+export MAC_CUSTOM_PREFIX="C0:00"
+./scripts/vm.sh create
+```
+
+### Example 4: Using .env file
+Add to your `.env` file:
+```bash
+MAC_ASSIGNMENT_METHOD=custom-prefix
+MAC_CUSTOM_PREFIX=C0:00
+```
+
+## Validation
+
+The script includes validation for:
+- MAC address format (proper hex format with colons)
+- Custom prefix format (2-digit hex or 4-digit hex with colon)
+- Machine-id file existence
+- Valid assignment method values
+
+## Error Handling
+
+The script will exit with an error if:
+- Invalid `MAC_ASSIGNMENT_METHOD` is specified
+- `MAC_CUSTOM_PREFIX` is missing when using "custom-prefix" method
+- Machine-id file is not found when using "machine-id" method
+- Generated MAC address is invalid
+
+## Notes
+
+- All generated MAC addresses use the locally administered address space (52:54:00 prefix)
+- Machine-id based MACs are deterministic and will be the same for the same VM name on the same host
+- Custom prefix MACs are predictable and follow a simple numbering scheme
+- The script maintains backward compatibility - existing deployments will continue to work unchanged 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -67,6 +67,10 @@ DISK_SIZE1=${DISK_SIZE1:-"120"}
 DISK_SIZE2=${DISK_SIZE2:-"80"}
 VM_PREFIX=${VM_PREFIX:-"vm-dpf"}
 
+# MAC Address Configuration
+MAC_ASSIGNMENT_METHOD=${MAC_ASSIGNMENT_METHOD:-"none"}  # Options: "none", "machine-id", "custom-prefix"
+MAC_CUSTOM_PREFIX=${MAC_CUSTOM_PREFIX:-"C0:00"}  # Required when MAC_ASSIGNMENT_METHOD="custom-prefix"
+
 # Paths
 DISK_PATH=${DISK_PATH:-"/var/lib/libvirt/images"}
 ISO_FOLDER=${ISO_FOLDER:-${DISK_PATH}}

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -68,8 +68,7 @@ DISK_SIZE2=${DISK_SIZE2:-"80"}
 VM_PREFIX=${VM_PREFIX:-"vm-dpf"}
 
 # MAC Address Configuration
-MAC_ASSIGNMENT_METHOD=${MAC_ASSIGNMENT_METHOD:-"none"}  # Options: "none", "machine-id", "custom-prefix"
-MAC_CUSTOM_PREFIX=${MAC_CUSTOM_PREFIX:-"C0:00"}  # Required when MAC_ASSIGNMENT_METHOD="custom-prefix"
+MAC_PREFIX=${MAC_PREFIX:-""}  # If set, use custom-prefix method, otherwise use machine-id
 
 # Paths
 DISK_PATH=${DISK_PATH:-"/var/lib/libvirt/images"}

--- a/scripts/vm.sh
+++ b/scripts/vm.sh
@@ -56,16 +56,123 @@ function create_vms() {
         echo "Skipping bridge creation as SKIP_BRIDGE_CONFIG is set to true."
     fi
 
-    # Create VMs
+    # --- MAC Address Generation Functions ---
+    
+    # Function to validate MAC address format
+    validate_mac_address() {
+        local mac="$1"
+        if [[ ! "$mac" =~ ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$ ]]; then
+            return 1
+        fi
+        return 0
+    }
+
+    # Function to generate a unique MAC address based on machine-id and VM name
+    generate_mac_from_machine_id() {
+        local vm_name="$1"
+        
+        # Try to get machine-id from common locations
+        local machine_id=""
+        if [ -f "/etc/machine-id" ]; then
+            machine_id=$(cat /etc/machine-id)
+        elif [ -f "/var/lib/dbus/machine-id" ]; then
+            machine_id=$(cat /var/lib/dbus/machine-id)
+        else
+            log "ERROR" "Could not find machine-id file. Please ensure /etc/machine-id or /var/lib/dbus/machine-id exists."
+            exit 1
+        fi
+
+        local combined="${machine_id}-${vm_name}"
+        local hash=$(echo "$combined" | sha256sum | cut -c1-10)
+        
+        # Use QEMU's standard locally administered MAC prefix (52:54:00)
+        local mac="52:54:00:$(echo "$hash" | sed 's/\(..\)\(..\)\(..\).*/\1:\2:\3/')"
+        
+        if ! validate_mac_address "$mac"; then
+            log "ERROR" "Generated invalid MAC address: $mac"
+            exit 1
+        fi
+        
+        echo "$mac"
+    }
+
+    # Function to generate MAC address with custom prefix
+    generate_mac_with_custom_prefix() {
+        local vm_index="$1"
+        local custom_prefix="$2"
+        
+        # Validate custom prefix format (should be 2 hex digits or 4 hex digits with colon)
+        if [[ ! "$custom_prefix" =~ ^[0-9A-Fa-f]{2}$ ]] && [[ ! "$custom_prefix" =~ ^[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}$ ]]; then
+            log "ERROR" "Invalid MAC_CUSTOM_PREFIX format: $custom_prefix. Must be 2 hexadecimal digits (e.g., '01', 'A1') or 4 hex digits with colon (e.g., 'C0:00')"
+            exit 1
+        fi
+        
+        # Convert VM index to hex (01, 02, 03, etc.)
+        local last_octet_hex=$(printf '%02x' "$vm_index")
+        
+        # Handle both formats: "C0:00" and "C0"
+        if [[ "$custom_prefix" =~ : ]]; then
+            # Format: "C0:00" -> use as is
+            local mac="52:54:00:${custom_prefix}:${last_octet_hex}"
+        else
+            # Format: "C0" -> add ":00"
+            local mac="52:54:00:${custom_prefix}:00:${last_octet_hex}"
+        fi
+        
+        if ! validate_mac_address "$mac"; then
+            log "ERROR" "Generated invalid MAC address: $mac"
+            exit 1
+        fi
+        
+        echo "$mac"
+    }
+
+    # --- VM Creation Loop ---
     for i in $(seq 1 "$VM_COUNT"); do
         VM_NAME="${VM_PREFIX}${i}"
-        echo "Creating VM: $VM_NAME"
-        nohup virt-install --name "$VM_NAME" --memory $RAM \
+        network_mac_arg=""
+
+        case "$MAC_ASSIGNMENT_METHOD" in
+            "machine-id")
+                # Option 2: Use the machine-id based MAC mechanism
+                UNIQUE_MAC=$(generate_mac_from_machine_id "$VM_NAME")
+                log "INFO" "Creating VM: $VM_NAME with machine-id based MAC: $UNIQUE_MAC"
+                network_mac_arg=",mac=${UNIQUE_MAC}"
+                ;;
+            "custom-prefix")
+                # Option 3: Use the custom prefix mechanism
+                if [ -z "$MAC_CUSTOM_PREFIX" ] || [ "$MAC_CUSTOM_PREFIX" = "none" ]; then
+                    log "ERROR" "MAC_ASSIGNMENT_METHOD is 'custom-prefix' but MAC_CUSTOM_PREFIX is not set or is 'none'."
+                    log "ERROR" "Please set MAC_CUSTOM_PREFIX to a 2-digit hex value (e.g., '01', 'A1') or 4 hex digits with colon (e.g., 'C0:00')"
+                    exit 1
+                fi
+                UNIQUE_MAC=$(generate_mac_with_custom_prefix "$i" "$MAC_CUSTOM_PREFIX")
+                log "INFO" "Creating VM: $VM_NAME with custom prefix MAC: $UNIQUE_MAC"
+                network_mac_arg=",mac=${UNIQUE_MAC}"
+                ;;
+            "none"|"")
+                # Option 1: Use the original code (no static MAC assigned)
+                log "INFO" "Creating VM: $VM_NAME with auto-generated MAC (no custom assignment method specified)."
+                # network_mac_arg remains empty
+                ;;
+            *)
+                log "ERROR" "Invalid MAC_ASSIGNMENT_METHOD: $MAC_ASSIGNMENT_METHOD"
+                log "ERROR" "Valid options are: 'none', 'machine-id', 'custom-prefix'"
+                exit 1
+                ;;
+        esac
+
+        # Construct the full --network argument string
+        network_full_arg="bridge=${BRIDGE_NAME},model=e1000e${network_mac_arg}"
+
+        # Create VM with virt-install
+        log "INFO" "Starting VM creation for $VM_NAME..."
+        nohup virt-install --name "$VM_NAME" --memory "$RAM" \
                 --vcpus "$VCPUS" \
                 --os-variant=rhel9.4 \
                 --disk pool=default,size="${DISK_SIZE1}" \
                 --disk pool=default,size="${DISK_SIZE2}" \
-                --network bridge=${BRIDGE_NAME},model=e1000e \
+                --network "${network_full_arg}" \
                 --graphics=vnc \
                 --events on_reboot=restart \
                 --cdrom "$ISO_PATH" \


### PR DESCRIPTION
- Add three MAC assignment methods: none, machine-id, custom-prefix
- Support both 2-digit and 4-digit custom prefixes (default: C0:00)
- Add comprehensive validation and error handling
- Add documentation with usage examples
- Maintain backward compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable MAC address assignment methods for virtual machines, supporting machine-id based deterministic and custom prefix options.
  * Introduced an environment variable to control MAC address assignment behavior and custom prefix usage.

* **Documentation**
  * Added detailed documentation describing MAC address configuration options, usage examples, validation rules, and error handling for VM creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->