### PR TITLE
Migration guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -51,7 +51,8 @@ Notable changes:
 - DPFOperatorConfigSpec.OVSHelper is no longer available. This component is no longer deployed by the DPF Operator.
 - DPFOperatorConfigSpec.FlannelConfiguration.PodCIDR can now be set.
 - DPUClusterSpec.Version can no longer be set. This is now a status field.
-- 
+
+DPUCluster expects secret to contain a key `super-admin.conf`. Previously this key was `admin.conf`.
 
 Below is a full set of API changes in the `operator`, `dpuservice` and `provisioning` API groups:
 

--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -235,10 +235,10 @@ function copy_hypershift_kubeconfig() {
     
     # Create or update secret in dpf-operator-system namespace
     if ! oc create secret generic ${HOSTED_CLUSTER_NAME}-admin-kubeconfig -n dpf-operator-system \
-         --from-file=admin.conf=./${HOSTED_CLUSTER_NAME}.kubeconfig --type=Opaque 2>/dev/null; then
+         --from-file=super-admin.conf=./${HOSTED_CLUSTER_NAME}.kubeconfig --type=Opaque 2>/dev/null; then
         log [INFO] "Secret already exists, updating..."
         if ! oc -n dpf-operator-system create secret generic ${HOSTED_CLUSTER_NAME}-admin-kubeconfig \
-             --from-file=admin.conf=./${HOSTED_CLUSTER_NAME}.kubeconfig --type=Opaque --dry-run=client -o yaml | oc apply -f -; then
+             --from-file=super-admin.conf=./${HOSTED_CLUSTER_NAME}.kubeconfig --type=Opaque --dry-run=client -o yaml | oc apply -f -; then
             log [ERROR] "Failed to update kubeconfig secret"
             return 1
         fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a migration guide for upgrading from DPF version 25.4.0 to 25.7.0-beta.4, detailing required steps, API changes, and configuration updates for HBN/OVN-Kubernetes use cases.

* **Bug Fixes**
  * Updated the key name for the kubeconfig file in Kubernetes secrets from `admin.conf` to `super-admin.conf` to ensure correct configuration during secret creation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->