### PR TITLE
br-comm-ch NetworkManager static mac address

### DIFF
--- a/scripts/gen_template.py
+++ b/scripts/gen_template.py
@@ -100,6 +100,9 @@ interface-name=br-comm-ch
 autoconnect-ports=1
 autoconnect-slaves=1
 
+[ethernet]
+cloned-mac-address=stable
+
 [bridge]
 stp=false
 


### PR DESCRIPTION
This PR makes the `br-comm-ch` get an static assigned MAC address by NetworkManager, this will ensure the nodes boot with the same IP address and prevent various identification issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Ethernet configuration option to set a stable cloned MAC address for the bridge network interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->