### PR TITLE
Add kamajiEtcdDefrag.enabled=false to DPF helm installation

### DIFF
--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -304,7 +304,8 @@ function apply_dpf() {
         "${CHART_URL}" \
         --namespace dpf-operator-system \
         --create-namespace \
-        --values "${HELM_CHARTS_DIR}/dpf-operator-values.yaml"; then
+        --values "${HELM_CHARTS_DIR}/dpf-operator-values.yaml" \
+        --set kamajiEtcdDefrag.enabled=false; then
         
         log "INFO" "Helm release 'dpf-operator' deployed successfully"
         log "INFO" "DPF Operator deployment initiated. Use 'oc get pods -n dpf-operator-system' to monitor progress."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment script to disable Kamaji Etcd defragmentation during Helm chart installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->