### PR TITLE
fix: Add missing BlueField and OVS configuration files to ignition template

### DIFF
--- a/scripts/gen_template.py
+++ b/scripts/gen_template.py
@@ -71,6 +71,29 @@ FILES_PLAIN: list[FileEntry] = [
 
 FILES: list[FileEntry] = [
     FileEntry(
+        path="/etc/mellanox/mlnx-bf.conf",
+        overwrite=True,
+        mode=644,
+        contents=FileContents(
+            inline="""
+ALLOW_SHARED_RQ="no"
+IPSEC_FULL_OFFLOAD="no"
+ENABLE_ESWITCH_MULTIPORT="yes"
+"""
+        )
+    ),
+    FileEntry(
+        path="/etc/mellanox/mlnx-ovs.conf",
+        overwrite=True,
+        mode=644,
+        contents=FileContents(
+            inline="""
+CREATE_OVS_BRIDGES="no"
+OVS_DOCA="yes"
+"""
+        )
+    ),
+    FileEntry(
         path="/etc/NetworkManager/system-connections/pf0vf0.nmconnection",
         overwrite=True,
         mode=600,


### PR DESCRIPTION
without those files OVS is crashing and offload is not working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic generation of two new configuration files for Mellanox devices: `mlnx-bf.conf` and `mlnx-ovs.conf`, each with predefined settings, as part of the ignition configuration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->