### PR TITLE
Enable reverse path filtering in loose mode

### DIFF
--- a/scripts/gen_template.py
+++ b/scripts/gen_template.py
@@ -194,6 +194,7 @@ method=disabled
 net.ipv4.ip_forward=1
 net.bridge.bridge-nf-call-iptables=1
 net.bridge.bridge-nf-call-ip6tables=1
+net.ipv4.conf.all.rp_filter=2
 """
         )
     ),


### PR DESCRIPTION
Set `net.ipv4.conf.all.rp_filter=2` so reverse path filtering works with asymmetric routing and multiple interfaces. Loose mode still checks source validity but won’t drop packets just because they arrive on a different interface than the route back.