### PR TITLE
Feature/move kamaji etcd defrag to values

### DIFF
--- a/manifests/helm-charts-values/dpf-operator-values.yaml
+++ b/manifests/helm-charts-values/dpf-operator-values.yaml
@@ -4,6 +4,8 @@ kamaji:
   enabled: false
 kamaji-etcd:
   enabled: false
+  kamajiEtcdDefrag:
+    enabled: false
 node-feature-discovery:
   enabled: false
 isOpenshift: true

--- a/manifests/helm-charts-values/dpf-operator-values.yaml
+++ b/manifests/helm-charts-values/dpf-operator-values.yaml
@@ -1,11 +1,7 @@
 imagePullSecrets:
   - name: dpf-pull-secret
-kamaji:
+kamajiEtcdDefrag:
   enabled: false
-kamaji-etcd:
-  enabled: false
-  kamajiEtcdDefrag:
-    enabled: false
 node-feature-discovery:
   enabled: false
 isOpenshift: true

--- a/manifests/helm-charts-values/dpf-operator-values.yaml
+++ b/manifests/helm-charts-values/dpf-operator-values.yaml
@@ -2,6 +2,4 @@ imagePullSecrets:
   - name: dpf-pull-secret
 kamajiEtcdDefrag:
   enabled: false
-node-feature-discovery:
-  enabled: false
 isOpenshift: true

--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -415,8 +415,7 @@ function apply_dpf() {
         ${HELM_ARGS} \
         --namespace dpf-operator-system \
         --create-namespace \
-        --values "${HELM_CHARTS_DIR}/dpf-operator-values.yaml" \
-        --set kamajiEtcdDefrag.enabled=false; then
+        --values "${HELM_CHARTS_DIR}/dpf-operator-values.yaml"; then
         
         log "INFO" "Helm release 'dpf-operator' deployed successfully"
         log "INFO" "DPF Operator deployment initiated. Use 'oc get pods -n dpf-operator-system' to monitor progress."


### PR DESCRIPTION
and removed un-needed values (Kamaji and NFD are not installed by DPF anymore)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a unified configuration flag for etcd defragmentation (kamajiEtcdDefrag.enabled).

- Refactor
  - Consolidated chart values by removing legacy keys (kamaji.enabled, kamaji-etcd.enabled, node-feature-discovery) in favor of the new defrag configuration.

- Chores
  - Deployment no longer forces etcd defragmentation to be disabled; it now respects chart defaults or user-provided values.
  - Existing settings like image pull secrets and OpenShift mode remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->