### PR TITLE
Increased crio ulimit for open files

### DIFF
--- a/scripts/gen_template.py
+++ b/scripts/gen_template.py
@@ -186,6 +186,17 @@ method=disabled
 """)
     ),
     FileEntry(
+        path="/etc/crio/crio.conf.d/99-ulimits.conf",
+        overwrite=True,
+        mode=644,
+        contents=FileContents(
+            inline="""[crio.runtime]
+default_ulimits = [
+  "nofile=4096:8192"
+]
+""")
+    ),
+    FileEntry(
         path="/etc/sysctl.d/98-dpunet.conf",
         overwrite=True,
         mode=644,

--- a/scripts/gen_template.py
+++ b/scripts/gen_template.py
@@ -192,7 +192,7 @@ method=disabled
         contents=FileContents(
             inline="""[crio.runtime]
 default_ulimits = [
-  "nofile=4096:8192"
+  "nofile=524288:524288"
 ]
 """)
     ),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure default container runtime ulimits to set nofile to 524288:524288.
  * Improves stability for workloads that open many files or network connections.
  * Reduces the likelihood of “too many open files” errors under high load; no impact expected for typical workloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->