### PR TITLE
Add MTU options for dpu deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ V25.7-FINAL-SUMMARY.md
 # Verification scripts
 verify-v25.7.sh
 	
+.vscode/

--- a/manifests/post-installation/dpu-service-nads.yaml
+++ b/manifests/post-installation/dpu-service-nads.yaml
@@ -7,7 +7,7 @@ spec:
   resourceType: sf
   ipam: false
   bridge: "br-hbn"
-  serviceMTU: 1500
+  serviceMTU: <SVC_MTU>
 --- 
 apiVersion: svc.dpu.nvidia.com/v1alpha1
 kind: DPUServiceNAD
@@ -18,4 +18,4 @@ spec:
   resourceType: sf
   ipam: true
   bridge: "br-sfc"
-  serviceMTU: 1500
+  serviceMTU: <SVC_MTU>

--- a/manifests/post-installation/dpuflavor-9000.yaml
+++ b/manifests/post-installation/dpuflavor-9000.yaml
@@ -1,0 +1,40 @@
+apiVersion: provisioning.dpu.nvidia.com/v1alpha1
+kind: DPUFlavor
+metadata:
+  name: flavor-9000
+  namespace: dpf-operator-system
+spec:
+  bfcfgParameters:
+    - UPDATE_ATF_UEFI=yes
+    - UPDATE_DPU_OS=yes
+    - WITH_NIC_FW_UPDATE=yes
+  grub:
+    kernelParameters:
+      - console=hvc0
+      - console=ttyAMA0
+      - earlycon=pl011,0x13010000
+      - fixrttc
+      - net.ifnames=0
+      - biosdevname=0
+      - iommu.passthrough=1
+      - cgroup_no_v1=net_prio,net_cls
+      - hugepagesz=2048kB
+      - hugepages=8072
+  nvconfig:
+    - device: '*'
+      parameters:
+        - PF_BAR2_ENABLE=0
+        - PER_PF_NUM_SF=1
+        - PF_TOTAL_SF=20
+        - PF_SF_BAR_SIZE=10
+        - NUM_PF_MSIX_VALID=0
+        - PF_NUM_PF_MSIX_VALID=1
+        - PF_NUM_PF_MSIX=228
+        - INTERNAL_CPU_MODEL=1
+        - INTERNAL_CPU_OFFLOAD_ENGINE=0
+        - SRIOV_EN=1
+        - NUM_OF_VFS=<NUM_VFS>
+        - LAG_RESOURCE_ALLOCATION=1
+        - NUM_VF_MSIX=48
+  ovs:
+    rawConfigScript: IyEvYmluL2Jhc2gKCgpfb3ZzLXZzY3RsKCkgewogIG92cy12c2N0bCAtLW5vLXdhaXQgLS10aW1lb3V0IDE1ICIkQCIKfQoKX292cy12c2N0bCBzZXQgT3Blbl92U3dpdGNoIC4gb3RoZXJfY29uZmlnOmRvY2EtaW5pdD10cnVlCl9vdnMtdnNjdGwgc2V0IE9wZW5fdlN3aXRjaCAuIG90aGVyX2NvbmZpZzpkcGRrLW1heC1tZW16b25lcz01MDAwMApfb3ZzLXZzY3RsIHNldCBPcGVuX3ZTd2l0Y2ggLiBvdGhlcl9jb25maWc6aHctb2ZmbG9hZD10cnVlCl9vdnMtdnNjdGwgc2V0IE9wZW5fdlN3aXRjaCAuIG90aGVyX2NvbmZpZzpwbWQtcXVpZXQtaWRsZT10cnVlCl9vdnMtdnNjdGwgc2V0IE9wZW5fdlN3aXRjaCAuIG90aGVyX2NvbmZpZzptYXgtaWRsZT0yMDAwMApfb3ZzLXZzY3RsIHNldCBPcGVuX3ZTd2l0Y2ggLiBvdGhlcl9jb25maWc6bWF4LXJldmFsaWRhdG9yPTUwMDAKX292cy12c2N0bCBzZXQgT3Blbl92U3dpdGNoIC4gb3RoZXJfY29uZmlnOmN0bC1waXBlLXNpemU9MTAyNApfb3ZzLXZzY3RsIC0taWYtZXhpc3RzIGRlbC1iciBvdnNicjEKX292cy12c2N0bCAtLWlmLWV4aXN0cyBkZWwtYnIgb3ZzYnIyCl9vdnMtdnNjdGwgLS1tYXktZXhpc3QgYWRkLWJyIGJyLXNmYwpfb3ZzLXZzY3RsIHNldCBicmlkZ2UgYnItc2ZjIGRhdGFwYXRoX3R5cGU9bmV0ZGV2Cl9vdnMtdnNjdGwgc2V0IGJyaWRnZSBici1zZmMgZmFpbF9tb2RlPXNlY3VyZQpfb3ZzLXZzY3RsIC0tbWF5LWV4aXN0IGFkZC1iciBici1oYm4KX292cy12c2N0bCBzZXQgYnJpZGdlIGJyLWhibiBkYXRhcGF0aF90eXBlPW5ldGRldgpfb3ZzLXZzY3RsIHNldCBicmlkZ2UgYnItaGJuIGZhaWxfbW9kZT1zZWN1cmUKX292cy12c2N0bCAtLW1heS1leGlzdCBhZGQtcG9ydCBici1zZmMgcDAKX292cy12c2N0bCBzZXQgSW50ZXJmYWNlIHAwIHR5cGU9ZHBkawpfb3ZzLXZzY3RsIHNldCBJbnRlcmZhY2UgcDAgbXR1X3JlcXVlc3Q9OTIxNgpfb3ZzLXZzY3RsIHNldCBQb3J0IHAwIGV4dGVybmFsX2lkczpkcGYtdHlwZT1waHlzaWNhbApfb3ZzLXZzY3RsIC0tbWF5LWV4aXN0IGFkZC1wb3J0IGJyLXNmYyBwMQpfb3ZzLXZzY3RsIHNldCBJbnRlcmZhY2UgcDEgdHlwZT1kcGRrCl9vdnMtdnNjdGwgc2V0IEludGVyZmFjZSBwMSBtdHVfcmVxdWVzdD05MjE2Cl9vdnMtdnNjdGwgc2V0IFBvcnQgcDEgZXh0ZXJuYWxfaWRzOmRwZi10eXBlPXBoeXNpY2FsCiAKX292cy12c2N0bCBzZXQgT3Blbl92U3dpdGNoIC4gZXh0ZXJuYWwtaWRzOm92bi1icmlkZ2UtZGF0YXBhdGgtdHlwZT1uZXRkZXYKX292cy12c2N0bCAtLW1heS1leGlzdCBhZGQtYnIgYnItb3ZuCl9vdnMtdnNjdGwgc2V0IGJyaWRnZSBici1vdm4gZGF0YXBhdGhfdHlwZT1uZXRkZXYKX292cy12c2N0bCBici1zZXQtZXh0ZXJuYWwtaWQgYnItb3ZuIGJyaWRnZS1pZCBici1vdm4KX292cy12c2N0bCBici1zZXQtZXh0ZXJuYWwtaWQgYnItb3ZuIGJyaWRnZS11cGxpbmsgcHVwbGlua2Jyb3ZudG9icnNmYwpfb3ZzLXZzY3RsIHNldCBJbnRlcmZhY2UgYnItb3ZuIG10dV9yZXF1ZXN0PTkyMTYKX292cy12c2N0bCAtLW1heS1leGlzdCBhZGQtcG9ydCBici1vdm4gcGYwaHBmCl9vdnMtdnNjdGwgc2V0IEludGVyZmFjZSBwZjBocGYgdHlwZT1kcGRrCl9vdnMtdnNjdGwgc2V0IEludGVyZmFjZSBwZjBocGYgbXR1X3JlcXVlc3Q9OTIxNgoKCg==

--- a/manifests/post-installation/ovn-configuration.yaml
+++ b/manifests/post-installation/ovn-configuration.yaml
@@ -13,7 +13,7 @@ spec:
         k8sAPIServer: https://<HOST_CLUSTER_API>:6443
         podNetwork: 10.128.0.0/16
         serviceNetwork: 172.30.0.0/16
-        mtu: 1400
+        mtu: <NODES_MTU>
         dpuManifests:
           kubernetesSecretName: "ovn-dpu"
           vtepCIDR: "<HBN_OVN_NETWORK>"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -38,10 +38,19 @@ load_env() {
     done < "$env_file"
 }
 
+validate_mtu() {
+    if [ "$NODES_MTU" != "1500" ] && [ "$NODES_MTU" != "9000" ]; then
+        echo "Error: NODES_MTU must be either 1500 or 9000. Current value: $NODES_MTU"
+        exit 1
+    fi
+}
+
 # Load environment variables from .env file (skip if already in Make context)
 if [ -z "${MAKELEVEL:-}" ]; then
     load_env
+    validate_mtu
 fi
+
 # Directory Configuration
 MANIFESTS_DIR=${MANIFESTS_DIR:-"manifests"}
 GENERATED_DIR=${GENERATED_DIR:-"$MANIFESTS_DIR/generated"}

--- a/scripts/manifests.sh
+++ b/scripts/manifests.sh
@@ -225,6 +225,17 @@ prepare_dpf_manifests() {
         "<CLUSTER_NAME>" "$CLUSTER_NAME" \
         "<BASE_DOMAIN>" "$BASE_DOMAIN"
     
+    if [ -n "$NODES_MTU" ] && [ "$NODES_MTU" == "9000" ]; then
+        log "INFO" "Appending networking configuration with MTU: $NODES_MTU"
+        cat >> "$GENERATED_DIR/dpfoperatorconfig.yaml" <<-EOF
+  networking:
+    controlPlaneMTU: $NODES_MTU
+    highSpeedMTU: $NODES_MTU
+EOF
+    else
+       log "INFO" "NODES_MTU is not set. Skipping networking configuration."
+    fi
+
     # Final verification: ensure no Helm values files are in the generated directory
     if find "$GENERATED_DIR" -maxdepth 1 -type f -name "*-values.yaml" | grep -q .; then
         log "ERROR" "Helm values files found in generated directory. These should not be processed during cluster installation."
@@ -244,7 +255,7 @@ function update_ovn_mtu_in_value_file() {
     if [[ -n "$NODES_MTU" ]] && [[ "$NODES_MTU" != "1500" ]]; then
         echo "NODES_MTU is defined as $NODES_MTU. Updating MTU in $ovn_values_file."
 
-        local new_mtu=$((NODES_MTU - 100))
+        local new_mtu=$((NODES_MTU - 60))
         if grep -Eq '^[[:space:]]*mtu:' "$ovn_values_file"; then
            sed -i "s/mtu:.*/mtu: $new_mtu/" "$ovn_values_file"
         else


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 9000 MTU DPU flavor (flavor-9000), dpu-service NAD templating, and automatic flavor selection based on node MTU (1500 or 9000). OVN MTU is now parameterized from node MTU.

* **Bug Fixes**
  * Adjusted OVN MTU calculation to use a 60-byte offset (was 100).

* **Chores**
  * Added MTU validation, improved post-install logging and manifest handling, updated special files list, and ignored IDE workspace settings (.vscode).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->