### PR TITLE
no need to copy to same filepath

### DIFF
--- a/scripts/cluster.sh
+++ b/scripts/cluster.sh
@@ -264,7 +264,6 @@ function get_kubeconfig() {
     if [ ! -f "$kubeconfig_path" ]; then
         log "INFO" "Downloading kubeconfig for $CLUSTER_NAME"
         aicli download kubeconfig "$CLUSTER_NAME"
-        cp "kubeconfig.$CLUSTER_NAME" "$kubeconfig_path"
         log "INFO" "Kubeconfig downloaded to $KUBECONFIG"
     else
         log "INFO" "Using existing kubeconfig at: $KUBECONFIG"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined kubeconfig handling by removing a redundant file copy during cluster setup.
  * The script now expects kubeconfig to be available at the configured path provided by the download step or environment.
  * Existing logging, validation, and environment export behavior remain unchanged.
  * Reduces side effects and potential conflicts in environments with pre-provisioned configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->