### PR TITLE
Remove custom hypershift control plane images

### DIFF
--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -157,8 +157,7 @@ function deploy_hypershift() {
           --network-type=Other \
           --etcd-storage-class="${ETCD_STORAGE_CLASS}" \
           --node-selector='node-role.kubernetes.io/master=""' \
-          --node-upgrade-type=Replace \
-          --control-plane-operator-image=quay.io/lhadad/controlplaneoperator:allCapsMultusDisabledV1
+          --node-upgrade-type=Replace
     fi
 
     log [INFO] "Adding CNO image override annotation..."

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -132,11 +132,7 @@ MAINTENANCE_OPERATOR_VERSION=${MAINTENANCE_OPERATOR_VERSION:-"0.2.0"}
 
 # Hypershift Configuration
 ENABLE_HCP_MULTUS=${ENABLE_HCP_MULTUS:-"true"}
-if [ "${ENABLE_HCP_MULTUS}" = "true" ]; then
-    HYPERSHIFT_IMAGE=${HYPERSHIFT_IMAGE:-"quay.io/lhadad/hypershift:7jan24-v1"}
-else
-    HYPERSHIFT_IMAGE=${HYPERSHIFT_IMAGE:-"quay.io/hypershift/hypershift-operator:latest"}
-fi
+HYPERSHIFT_IMAGE=${HYPERSHIFT_IMAGE:-"quay.io/hypershift/hypershift-operator:latest"}
 HOSTED_CLUSTER_NAME=${HOSTED_CLUSTER_NAME:-"doca"}
 CLUSTERS_NAMESPACE=${CLUSTERS_NAMESPACE:-"clusters"}
 OCP_RELEASE_IMAGE=${OCP_RELEASE_IMAGE:-"quay.io/openshift-release-dev/ocp-release:4.14.0-ec.4-x86_64"}


### PR DESCRIPTION
## Summary
- Remove custom control-plane-operator-image parameter from hypershift create command
- Always use official hypershift-operator:latest instead of custom lhadad builds
- Simplify HYPERSHIFT_IMAGE logic to eliminate conditional custom image selection

## Benefits
- Uses maintained upstream images instead of custom builds
- Reduces dependency on external custom images
- Ensures latest official hypershift features and fixes

## Changes
- `scripts/dpf.sh`: Removed `--control-plane-operator-image=quay.io/lhadad/controlplaneoperator:allCapsMultusDisabledV1`
- `scripts/env.sh`: Always use `quay.io/hypershift/hypershift-operator:latest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added default values for hosted cluster name, clusters namespace, and OpenShift release image.
  - Introduced a derived hosted control plane namespace based on cluster name and namespace.
- Refactor
  - Simplified image selection by defaulting to the standard hypershift operator image, removing conditional logic.
  - Cleaned up cluster creation command by removing the operator image override and adjusting formatting.
- Chores
  - Streamlined environment configuration to reduce setup complexity and ensure consistent defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->