### PR TITLE
Use helm template with selective components for OVN injector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,8 @@ DPU_OVN_VF=ens7f0v1
 DPU_HOST_CIDR=10.6.130.0/24
 HBN_OVN_NETWORK=10.6.150.0/27
 
+INJECTOR_RESOURCE_NAME=openshift.io/bf3-p0-vfs
+
 # Pull Secret files
 OPENSHIFT_PULL_SECRET=openshift_pull.json
 DPF_PULL_SECRET=pull-secret.txt


### PR DESCRIPTION
## Summary
- Replace problematic helm template approach that redeployed entire OVN chart
- Use --set flags to disable all OVN components except injector
- Generate only injector manifests without affecting existing OVN deployment
- Add configurable INJECTOR_RESOURCE_NAME environment variable

## Problem Solved
- Previous approach used `helm template | oc apply` which redeployed entire OVN chart, overriding existing pods
- New approach generates only injector-related manifests (11 resources) without touching existing OVN components

## Benefits
- Maintains aicli workflow compatibility
- Prevents disruption of running OVN deployment
- Selective component deployment using helm template
- Configurable resource name for different environments

## Changes
- `scripts/enable-ovn-injector.sh`: Use selective helm template with component disabling
- `.env.example`: Add INJECTOR_RESOURCE_NAME configuration variable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable environment variable to set the OVN resource injector resource name, with a sensible default.
- Refactor
  - Simplified the injector enablement script to reduce setup complexity and improve reliability by removing intermediate templating steps.
- Chores
  - Updated example environment configuration to document the new variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->