### PR TITLE
Allow setting nfd and sriov cataloguesources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ POST_INSTALL_SCRIPT := scripts/post-install.sh
         download-iso fix-yaml-spacing create-vms delete-vms enable-storage cluster-install wait-for-ready \
         wait-for-installed wait-for-status cluster-start clean-all deploy-dpf kubeconfig deploy-nfd \
         install-hypershift install-helm deploy-dpu-services prepare-dpu-files upgrade-dpf create-day2-cluster get-day2-iso \
-        redeploy-dpu enable-ovn-injector deploy-argocd deploy-maintenance-operator configure-flannel
+        redeploy-dpu enable-ovn-injector deploy-argocd deploy-maintenance-operator configure-flannel \
+        deploy-core-operator-sources
 
 all: verify-files check-cluster create-vms prepare-manifests cluster-install update-etc-hosts kubeconfig deploy-dpf prepare-dpu-files deploy-dpu-services enable-ovn-injector
 	@echo ""
@@ -127,6 +128,9 @@ configure-flannel: deploy-dpu-services
 enable-ovn-injector: install-helm
 	@scripts/enable-ovn-injector.sh
 
+deploy-core-operator-sources:
+	@$(MANIFESTS_SCRIPT) deploy-core-operator-sources
+
 update-etc-hosts:
 	@scripts/update-etc-hosts.sh
 
@@ -155,6 +159,7 @@ help:
 	@echo "  get-day2-iso      - Get ISO URL for worker nodes with DPUs (uses day2 cluster)"
 	@echo "  download-iso      - Download the ISO for master nodes"
 	@echo "  prepare-manifests - Prepare required manifests"
+	@echo "  deploy-core-operator-sources - Deploy NFD & SR-IOV subscriptions and CatalogSource"
 	@echo "  delete-cluster    - Delete the cluster"
 	@echo "  clean            - Remove generated files"
 	@echo "  clean-all        - Delete cluster, VMs, and clean all generated files"

--- a/manifests/cluster-installation/4.19-cataloguesource.yaml
+++ b/manifests/cluster-installation/4.19-cataloguesource.yaml
@@ -1,0 +1,14 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: redhat-operators-v419
+  namespace: openshift-marketplace
+spec:
+  displayName: Red Hat Operators v4.19
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.19
+  priority: -100
+  publisher: Red Hat
+  sourceType: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 10m

--- a/manifests/cluster-installation/nfd-subscription.yaml
+++ b/manifests/cluster-installation/nfd-subscription.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   channel: "stable"
   name: nfd
-  source: redhat-operators
+  source: <CATALOG_SOURCE_NAME>
   sourceNamespace: openshift-marketplace
   installPlanApproval: Automatic
 ---

--- a/manifests/cluster-installation/sriov-subscription.yaml
+++ b/manifests/cluster-installation/sriov-subscription.yaml
@@ -22,5 +22,5 @@ spec:
   channel: stable
   installPlanApproval: Automatic
   name: sriov-network-operator
-  source: redhat-operators
+  source: <CATALOG_SOURCE_NAME>
   sourceNamespace: openshift-marketplace

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -146,3 +146,6 @@ SLEEP_TIME=${SLEEP_TIME:-"60"}
 STATIC_NET_FILE=${STATIC_NET_FILE:-"./configuration_templates/static_net.yaml"}
 NODES_MTU=${NODES_MTU:-"1500"}
 PRIMARY_IFACE=${PRIMARY_IFACE:-enp1s0}
+
+# OLM Catalog Source Configuration
+CATALOG_SOURCE_NAME=${CATALOG_SOURCE_NAME:-"redhat-operators"}


### PR DESCRIPTION
This allows us to fix OLM issues with 4.20-ec5 and further

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a deploy command/target to install NFD and SR-IOV subscriptions along with a CatalogSource.
  - Introduced support for configuring the catalog source name via environment variable (defaults to Red Hat Operators).
  - Included a CatalogSource for OpenShift 4.19 with periodic updates.

- Documentation
  - Help output now lists and describes the new deployment target for core operator sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->