### PR TITLE
install only if hypershift binary not found, fix same for helm in dpf.sh

### DIFF
--- a/scripts/dpf.sh
+++ b/scripts/dpf.sh
@@ -128,7 +128,7 @@ function deploy_hypershift() {
         log [INFO] "Hypershift operator already installed. Skipping deployment."
     else
         log [INFO] "Installing latest hypershift operator"
-        install_hypershift
+        ensure_hypershift_installed
     fi
 
     log [INFO] "Checking if Hypershift hosted cluster ${HOSTED_CLUSTER_NAME} already exists..."

--- a/scripts/tools.sh
+++ b/scripts/tools.sh
@@ -30,6 +30,15 @@ function install_helm() {
     log "INFO" "Helm installation complete. Installed version: $(helm version --short)"
 }
 
+function ensure_hypershift_installed() {
+    if ! command -v hypershift &> /dev/null; then
+      log "INFO" "Hypershift not found. Installing hypershift..."
+      install_hypershift
+    else
+      log "INFO" "Hypershift is already installed. Version: $(hypershift -v)"
+    fi
+}
+
 function install_hypershift() {
     log "INFO" "Installing Hypershift binary and operator..."
 
@@ -76,10 +85,10 @@ function main() {
 
     case "$command" in
         install-helm)
-            install_helm
+            ensure_helm_installed
             ;;
         install-hypershift)
-            install_hypershift
+            ensure_hypershift_installed
             ;;
         *)
             log "Unknown command: $command"


### PR DESCRIPTION
Only install hypershift if not already available. Using the same logic as helm installation by creating ensure_hypershift_installed(). 
