### PR TITLE
Making HBN configuration scalable (BGP ASN config)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,6 @@ help:
 	@echo "Post-installation Configuration:"
 	@echo "  BFB_URL          - URL for BFB file (default: http://10.8.2.236/bfb/rhcos_4.19.0-ec.4_installer_2025-04-23_07-48-42.bfb)"
 	@echo "  HBN_OVN_NETWORK  - Network for HBN OVN IPAM (default: 10.0.120.0/22)"
-	@echo "  HBN_HOSTNAME_NODE - HBN node hostname (HBN_HOSTNAME_NODE<NODE_ID>, default: $(HBN_HOSTNAME_NODE1),$(HBN_HOSTNAME_NODE2))"
 	@echo ""
 	@echo "Wait Configuration:"
 	@echo "  MAX_RETRIES      - Maximum number of retries for status checks (default: $(MAX_RETRIES))"

--- a/manifests/post-installation/hbn-asn-ipam.yaml
+++ b/manifests/post-installation/hbn-asn-ipam.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: svc.dpu.nvidia.com/v1alpha1
+kind: DPUServiceIPAM
+metadata:
+  name: asn
+  namespace: dpf-operator-system
+spec:
+  ipv4Network:
+    network: "192.168.0.0/22"
+    prefixSize: 32

--- a/manifests/post-installation/hbn-configuration.yaml
+++ b/manifests/post-installation/hbn-configuration.yaml
@@ -11,7 +11,8 @@ spec:
         k8s.v1.cni.cncf.io/networks: |-
           [
           {"name": "iprequest", "interface": "ip_lo", "cni-args": {"poolNames": ["loopback"], "poolType": "cidrpool"}},
-          {"name": "iprequest", "interface": "ip_pf2dpu2", "cni-args": {"poolNames": ["pool1"], "poolType": "cidrpool", "allocateDefaultGateway": true}}
+          {"name": "iprequest", "interface": "ip_pf2dpu2", "cni-args": {"poolNames": ["pool1"], "poolType": "cidrpool", "allocateDefaultGateway": true}},
+          {"name": "iprequest", "interface": "ip_asn", "cni-args": {"poolNames": ["asn"], "poolType": "cidrpool"}}
           ]
     helmChart:
       values:
@@ -20,12 +21,6 @@ spec:
             - hostnamePattern: "*"
               values:
                 bgp_peer_group: hbn
-            - hostnamePattern: "<HBN_HOSTNAME_NODE1>"
-              values:
-                bgp_autonomous_system: 65101
-            - hostnamePattern: "<HBN_HOSTNAME_NODE2>"
-              values:
-                bgp_autonomous_system: 65201
           startupYAMLJ2: |
             - header:
                 model: BLUEFIELD
@@ -52,7 +47,7 @@ spec:
                       mtu: 9000
                 router:
                   bgp:
-                    autonomous-system: {{ config.bgp_autonomous_system }}
+                    autonomous-system: {{ ( ipaddresses.ip_asn.ip.split(".")[2] | int ) * 256 + ( ipaddresses.ip_asn.ip.split(".")[3] | int ) + 65101 }}
                     enable: on
                     graceful-restart:
                       mode: full

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -55,10 +55,6 @@ BFB_URL=${BFB_URL:-"http://10.8.2.236/bfb/rhcos_4.19.0-ec.4_installer_2025-04-23
 # HBN OVN Configuration
 HBN_OVN_NETWORK=${HBN_OVN_NETWORK:-"10.0.120.0/22"}
 
-# DPU Service Configuration
-HBN_HOSTNAME_NODE1=${HBN_HOSTNAME_NODE1:-"srv24-*"}
-HBN_HOSTNAME_NODE2=${HBN_HOSTNAME_NODE2:-"srv25-*"}
-
 # HBN Service Template Configuration
 HBN_HELM_REPO_URL=${HBN_HELM_REPO_URL:-"https://helm.ngc.nvidia.com/nvidia/doca"}
 HBN_HELM_CHART_VERSION=${HBN_HELM_CHART_VERSION:-"1.0.3"}

--- a/scripts/post-install.sh
+++ b/scripts/post-install.sh
@@ -129,9 +129,7 @@ function update_hbn_ovn_manifests() {
     if [ -f "${POST_INSTALL_DIR}/hbn-configuration.yaml" ]; then
         update_file_multi_replace \
             "${POST_INSTALL_DIR}/hbn-configuration.yaml" \
-            "${GENERATED_POST_INSTALL_DIR}/hbn-configuration.yaml" \
-            "<HBN_HOSTNAME_NODE1>" "${HBN_HOSTNAME_NODE1}" \
-            "<HBN_HOSTNAME_NODE2>" "${HBN_HOSTNAME_NODE2}"
+            "${GENERATED_POST_INSTALL_DIR}/hbn-configuration.yaml"
     fi
 
     log [INFO] "HBN OVN manifests updated successfully"


### PR DESCRIPTION
No need to have perDPUValuesYAML with hostname or use the HBN_HOSTNAME_NODE params in automation.

Verified locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a DPUServiceIPAM resource manifest to manage IPv4 address allocation.
  - Introduced an ASN IP pool and dynamic BGP autonomous system computation based on assigned IPs.

- Chores
  - Removed deprecated hostname environment variables and related substitution logic from post-install scripts.

- Documentation
  - Shortened Makefile help output by removing the HBN_HOSTNAME_NODE description.

- Configuration
  - Updated network configuration to include ip_asn and eliminate hard-coded BGP AS numbers for improved flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->