### PR TITLE
Removed openvswitch old workaround

### DIFF
--- a/scripts/gen_template.py
+++ b/scripts/gen_template.py
@@ -250,13 +250,6 @@ done
 echo "Finished setting nvconfig parameters"
 """)
     ),
-    FileEntry(
-        path="/etc/sysconfig/openvswitch",
-        overwrite=True,
-        mode=600,
-        contents=FileContents(
-            inline="""OVS_USER_ID=\"root:root\"""")
-    ),
 ]
 
 SYSTEMD_UNITS: list[SystemdUnit] = [


### PR DESCRIPTION
This PR removes the old workaround that runs openvswitch as root, enabling it running as the default `openvswitch:hugetlbfs` or `openvswitch:openvswitch` according to what is default in the OVS package.