### PR TITLE
HBN 3.1 image with iptable binaries included

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -67,8 +67,8 @@ HBN_OVN_NETWORK=${HBN_OVN_NETWORK:-"10.0.120.0/22"}
 # HBN Service Template Configuration
 HBN_HELM_REPO_URL=${HBN_HELM_REPO_URL:-"https://helm.ngc.nvidia.com/nvidia/doca"}
 HBN_HELM_CHART_VERSION=${HBN_HELM_CHART_VERSION:-"1.0.3"}
-HBN_IMAGE_REPO=${HBN_IMAGE_REPO:-"nvcr.io/nvidia/doca/doca_hbn"}
-HBN_IMAGE_TAG=${HBN_IMAGE_TAG:-"3.1.0-doca3.1.0"}
+HBN_IMAGE_REPO=${HBN_IMAGE_REPO:-"quay.io/eelgaev/doca_hbn"}
+HBN_IMAGE_TAG=${HBN_IMAGE_TAG:-"release-3.1.0.7-doca3.1.0-RHTP"}
 
 # DTS Service Template Configuration
 DTS_HELM_REPO_URL=${DTS_HELM_REPO_URL:-"https://helm.ngc.nvidia.com/nvidia/doca"}


### PR DESCRIPTION
This PR changes the hbn image to an experimental 3.1 hbn image with iptables-legacy binaries included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the default container image repository and tag used by the HBN service template to a new registry and version.
  - Deployments relying on defaults will now pull the updated image automatically.
  - Environments with custom image settings are unaffected.
  - No functional changes; only default image source and version were adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->