### PR TITLE
MTU fix for br-comm-ch

### DIFF
--- a/scripts/gen_template.py
+++ b/scripts/gen_template.py
@@ -106,7 +106,7 @@ master=br-comm-ch
 slave-type=bridge
 
 [ethernet]
-mtu=9000
+mtu=9216
 
 [bridge-port]"""
         )


### PR DESCRIPTION
Increase MTU from 9000 to 9216 for the specified interface to support larger frame sizes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Increased the default MTU for the pf0vf0 NetworkManager connection from 9000 to 9216, enabling larger jumbo frames on compatible infrastructure.
  - Expected impact: potential throughput improvements and reduced overhead on supported networks; no functional changes otherwise.
  - Applies automatically where this connection template is used; existing configurations remain compatible.
  - No user action required unless custom MTU settings are desired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->