### PR TITLE
Remove storage class from example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,9 +66,6 @@ DISK_PATH=/var/lib/libvirt/images
 ISO_FOLDER=/var/lib/libvirt/images
 #ISO_TYPE=full
 
-# Storage Configuration
-BFB_STORAGE_CLASS=lvms-vg1
-ETCD_STORAGE_CLASS=lvms-vg1
 BFB_URL=http://bfb.example.com/rhcos_4.20.0-ec.4_coreos-installer_2025-07-17.bfb
 
 # Kubeconfig


### PR DESCRIPTION
By default we use storage classes depending on the cluster type, we can leave an option to override them but need to remove it from example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated the environment configuration example by removing an obsolete storage configuration section and related storage class variables. This streamlines setup and aligns the example with current defaults. Existing environments are unaffected; only the example is changed. Users who require custom storage settings should continue to define them in their local environment files as needed. No functional or behavioral changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->