### PR TITLE
Revert "Removed openvswitch old workaround"

### DIFF
--- a/scripts/gen_template.py
+++ b/scripts/gen_template.py
@@ -250,6 +250,13 @@ done
 echo "Finished setting nvconfig parameters"
 """)
     ),
+    FileEntry(
+        path="/etc/sysconfig/openvswitch",
+        overwrite=True,
+        mode=600,
+        contents=FileContents(
+            inline="""OVS_USER_ID=\"root:root\"""")
+    ),
 ]
 
 SYSTEMD_UNITS: list[SystemdUnit] = [


### PR DESCRIPTION
This reverts commit 7135b37add5f46b074c053ae9c9e1b2cf7f3313f.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - During setup, a default Open vSwitch configuration is now written with secure permissions, ensuring the service runs under root:root. This improves out-of-the-box consistency, reduces potential permission-related issues, and standardizes deployments across environments. Applies only at setup time; existing behavior remains unchanged for running systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->