### PR TITLE
Run MetalLB only on control plane nodes

### DIFF
--- a/manifests/metallb/metallb-objects.yaml
+++ b/manifests/metallb/metallb-objects.yaml
@@ -3,6 +3,13 @@ kind: MetalLB
 metadata:
   name: metallb
   namespace: openshift-operators
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  speakerTolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
 
 ---
 apiVersion: metallb.io/v1beta1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MetalLB scheduling configuration to optimize resource allocation on control-plane nodes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->